### PR TITLE
Add Terraform infrastructure configuration for AWS S3 deployment

### DIFF
--- a/.github/workflows/scheduled-run.yml
+++ b/.github/workflows/scheduled-run.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-nicole-role
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
       
       - name: Run Docker container

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  terraform:
+    # docker compose run --rm terraform
+    image: hashicorp/terraform
+    tty: true
+    working_dir: /app
+    volumes:
+      - ./terraform:/app:delegated
+      - ~/.aws/:/root/.aws:delegated
+  aws-cli:
+    # docker compose run --rm aws-cli
+    image: amazon/aws-cli
+    tty: true
+    volumes:
+      - ~/.aws/:/root/.aws:delegated

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,30 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+*tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:wOhTPz6apLBuF7/FYZuCoXRK/MLgrNprZ3vXmq83g5k=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,108 @@
+# Nicole Terraform Configuration
+
+This directory contains Terraform configuration for provisioning AWS infrastructure for the Nicole project.
+
+## Resources Created
+
+- **S3 Bucket**: Public bucket for storing ranking JSON data
+  - Public read access (GetObject) for all users
+  - CORS configuration for browser access
+  - Versioning disabled
+- **OIDC Provider**: References existing GitHub Actions OIDC provider
+- **IAM Role**: Role for GitHub Actions with OIDC authentication
+- **IAM Policy**: Allows PutObject and ListBucket on the S3 bucket
+
+## Prerequisites
+
+1. AWS CLI installed and configured
+2. Terraform installed (>= 1.0)
+3. AWS credentials with sufficient permissions to create S3 buckets and IAM resources
+
+## Usage
+
+### Initialize Terraform
+
+```bash
+cd terraform
+terraform init
+```
+
+### Plan Changes
+
+```bash
+terraform plan
+```
+
+### Apply Configuration
+
+```bash
+terraform apply
+```
+
+### View Outputs
+
+```bash
+terraform output
+```
+
+## Configuration Variables
+
+You can customize variables in `variables.tf` or create a `terraform.tfvars` file:
+
+```hcl
+aws_region                = "ap-northeast-1"
+bucket_name               = "shibu1x-public"
+environment               = "production"
+github_actions_role_name  = "nicole-github-actions-role"
+github_repository         = "shibu1x/nicole"
+```
+
+## GitHub Actions Setup
+
+After applying the Terraform configuration:
+
+1. **Get the IAM Role ARN**:
+   ```bash
+   terraform output github_actions_role_arn
+   ```
+
+2. **Add Role ARN to GitHub Secrets**:
+   - Go to your repository Settings → Secrets and variables → Actions
+   - Add a new repository secret:
+     - Name: `AWS_ROLE_ARN`
+     - Value: The ARN from step 1 (e.g., `arn:aws:iam::123456789012:role/nicole-github-actions-role`)
+
+3. **Update GitHub Actions Workflow** to use OIDC authentication:
+   ```yaml
+   permissions:
+     id-token: write
+     contents: read
+
+   steps:
+     - name: Configure AWS credentials
+       uses: aws-actions/configure-aws-credentials@v4
+       with:
+         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+         aws-region: ap-northeast-1
+   ```
+
+4. **No long-lived access keys required** - OIDC authentication uses temporary credentials
+
+## Security Notes
+
+- Uses OIDC (OpenID Connect) for secure, keyless authentication
+- No long-lived access keys required
+- IAM role can only be assumed by GitHub Actions from the specified repository (default: `shibu1x/nicole`)
+- The S3 bucket allows public read access for all objects
+- Only the GitHub Actions role can write to the bucket
+- Temporary credentials are automatically rotated
+
+## Destroy Resources
+
+To remove all created resources:
+
+```bash
+terraform destroy
+```
+
+**Warning**: This will delete the S3 bucket and all its contents.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,147 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# S3 Bucket
+resource "aws_s3_bucket" "nicole_rankings" {
+  bucket = var.bucket_name
+
+  tags = {
+    Name        = "Nicole Rankings Data"
+    Environment = var.environment
+    ManagedBy   = "Terraform"
+  }
+}
+
+# S3 Bucket Public Access Block Configuration
+resource "aws_s3_bucket_public_access_block" "nicole_rankings" {
+  bucket = aws_s3_bucket.nicole_rankings.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+# S3 Bucket Policy for Public Read Access
+resource "aws_s3_bucket_policy" "nicole_rankings_public_read" {
+  bucket = aws_s3_bucket.nicole_rankings.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.nicole_rankings.arn}/*"
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.nicole_rankings]
+}
+
+# Reference existing OIDC Provider for GitHub Actions
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# IAM Role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name               = var.github_actions_role_name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "GitHub Actions Role"
+    Purpose     = "Upload ranking data to S3"
+    ManagedBy   = "Terraform"
+  }
+}
+
+# IAM Policy for S3 PutObject
+resource "aws_iam_policy" "github_actions_s3_upload" {
+  name        = "${var.bucket_name}-upload-policy"
+  description = "Allow GitHub Actions to upload objects to S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3Upload"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectAcl"
+        ]
+        Resource = "${aws_s3_bucket.nicole_rankings.arn}/*"
+      },
+      {
+        Sid    = "AllowS3ListBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = aws_s3_bucket.nicole_rankings.arn
+      }
+    ]
+  })
+}
+
+# Attach Policy to IAM Role
+resource "aws_iam_role_policy_attachment" "github_actions_s3_upload" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.github_actions_s3_upload.arn
+}
+
+# CORS Configuration (if needed for browser access)
+resource "aws_s3_bucket_cors_configuration" "nicole_rankings" {
+  bucket = aws_s3_bucket.nicole_rankings.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
+# Versioning disabled
+resource "aws_s3_bucket_versioning" "nicole_rankings" {
+  bucket = aws_s3_bucket.nicole_rankings.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,39 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.nicole_rankings.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.nicole_rankings.arn
+}
+
+output "bucket_domain_name" {
+  description = "Domain name of the S3 bucket"
+  value       = aws_s3_bucket.nicole_rankings.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "Regional domain name of the S3 bucket"
+  value       = aws_s3_bucket.nicole_rankings.bucket_regional_domain_name
+}
+
+output "github_actions_role_name" {
+  description = "IAM role name for GitHub Actions"
+  value       = aws_iam_role.github_actions.name
+}
+
+output "github_actions_role_arn" {
+  description = "ARN of the GitHub Actions IAM role"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider"
+  value       = data.aws_iam_openid_connect_provider.github_actions.arn
+}
+
+output "s3_upload_policy_arn" {
+  description = "ARN of the S3 upload policy"
+  value       = aws_iam_policy.github_actions_s3_upload.arn
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket for ranking data"
+  type        = string
+  default     = "shibu1x-public"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}
+
+variable "github_actions_role_name" {
+  description = "IAM role name for GitHub Actions"
+  type        = string
+  default     = "nicole-github-actions-role"
+}
+
+variable "github_repository" {
+  description = "GitHub repository in the format 'owner/repo'"
+  type        = string
+  default     = "shibu1x/nicole"
+}


### PR DESCRIPTION
## Summary

- Add Terraform configuration for AWS infrastructure management (S3 bucket, IAM, OIDC)
- Update GitHub Actions workflow to use AWS role ARN from secrets
- Add Docker Compose setup for local development with Terraform and AWS CLI

## Changes

### Terraform Infrastructure (`terraform/`)
- **S3 Bucket**: Public bucket for ranking data with CORS configuration
- **IAM Role**: GitHub Actions OIDC authentication (no access keys needed)
  - Restricted to `shibu1x/nicole` repository
  - Permissions: S3 PutObject, ListBucket
- **Security**: Repository-scoped access, no long-lived credentials

### GitHub Actions
- Updated `scheduled-run.yml` to use `secrets.AWS_ROLE_ARN` instead of hardcoded values
- Maintains existing workflow functionality

### Development Tooling
- Added `compose.yaml` for local Terraform/AWS CLI operations
- Provides consistent environment for infrastructure management

## Test Plan

- [ ] Verify Terraform configuration applies successfully
- [ ] Test GitHub Actions workflow with new AWS role authentication
- [ ] Confirm S3 uploads work with OIDC authentication
- [ ] Validate CORS configuration allows browser access to ranking data

🤖 Generated with [Claude Code](https://claude.com/claude-code)