### PR TITLE
Increase container version retention from 2 to 4

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -51,4 +51,4 @@ jobs:
         with:
           package-name: ${{ github.event.repository.name }}
           package-type: 'container'
-          min-versions-to-keep: 2
+          min-versions-to-keep: 4


### PR DESCRIPTION
## Summary

- Increase `min-versions-to-keep` from 2 to 4 in the backend build workflow to retain more historical container images

## Changes

- Update `.github/workflows/build-backend.yml` to keep 4 container versions instead of 2
- This allows for better rollback capabilities and version history

## Test plan

- [ ] Verify workflow runs successfully after merge
- [ ] Confirm container cleanup maintains 4 versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)