### PR TITLE
Update GHCR cleanup action and fix compose.yaml

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -46,9 +46,7 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      - name: Delete untagged images from GitHub Container Registry
-        uses: actions/delete-package-versions@v5
+      - name: Cleanup old images from GitHub Container Registry
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          package-name: ${{ github.event.repository.name }}
-          package-type: 'container'
-          min-versions-to-keep: 4
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,10 +6,10 @@ services:
     working_dir: /app
     volumes:
       - ./terraform:/app:delegated
-      - ~/.aws/:/root/.aws:delegated
+      - ~/.aws:/root/.aws:delegated
   aws-cli:
     # docker compose run --rm aws-cli
     image: amazon/aws-cli
     tty: true
     volumes:
-      - ~/.aws/:/root/.aws:delegated
+      - ~/.aws:/root/.aws:delegated


### PR DESCRIPTION
## Summary

- Update GitHub Container Registry cleanup action to use more efficient tool
- Fix AWS volume mount paths in compose.yaml

## Changes

### GitHub Actions Workflow
- Replace `actions/delete-package-versions` with `dataaxiom/ghcr-cleanup-action` in `.github/workflows/build-backend.yml`
- Simplifies configuration and provides more efficient container image cleanup

### Docker Compose
- Remove trailing slashes from AWS credentials volume mount paths in `compose.yaml`
- Improves consistency in volume path declarations

## Test Plan

- [ ] Verify GitHub Actions workflow runs successfully with new cleanup action
- [ ] Test Docker Compose services with updated volume mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)